### PR TITLE
Multi clients

### DIFF
--- a/main/electron.ts
+++ b/main/electron.ts
@@ -139,14 +139,17 @@ const restoreFiles = [
 // ///////////////////////////////////////////////////////
 // Main ----------------------------------
 
-const waitBusy = (limit: number = 10000) => new Promise((resolve, reject) => {
+const waitBusy = (clientIndex: number, limit: number = 10000) => new Promise((resolve, reject) => {
   let elapsed = 0;
   const p = () => {
     const title = '웹 페이지 메시지\0'; // null-terminated string
 
     const lpszWindow = Buffer.from(title, 'ucs2');
-    const hWnd = user32.FindWindowExW(null, null, null, lpszWindow);
-    if (hWnd && !hWnd.isNull()) {
+    const hWnd = user32.FindWindowExW(0, 0, null, lpszWindow);
+    if ((typeof hWnd === 'number' && hWnd > 0)
+      || (typeof hWnd === 'bigint' && hWnd > 0)
+      || (typeof hWnd === 'string' && hWnd.length > 0)
+    ) {
       // found alert window. This situation would appears when something went wrong.
       user32.SendMessageW(hWnd, 0x10, 0, 0);
       reject();
@@ -155,8 +158,8 @@ const waitBusy = (limit: number = 10000) => new Promise((resolve, reject) => {
       reject();
       return;
     }
-    if (IE && IE.Application) {
-      if ((!IE.Busy) || (IE.Busy.valueOf() !== false)) {
+    if (IE[clientIndex] && IE[clientIndex].Application) {
+      if (IE[clientIndex].Busy) {
         elapsed += 100;
         setTimeout(p, 100);
       } else {
@@ -321,7 +324,6 @@ app.on('second-instance', (event, commandLine, workingDirectory) => {
 
 ipcMain.on('request-login', async (event, arg) => {
   const { index, id, password } = arg;
-  console.log(index, id, password);
   closeIE(index);
   mainWindow.setProgressBar(0.1);
   IE[index] = new ActiveXObject('InternetExplorer.Application');
@@ -330,16 +332,20 @@ ipcMain.on('request-login', async (event, arg) => {
   currentIndex = index;
   try {
     IE[index].navigate('http://www.gersang.co.kr/main.gs');
-    await waitBusy();
-    return;
-
+    await waitBusy(index);
     logoutUser(index);
-    await waitBusy();
+    await waitBusy(index);
     IE[index].navigate('http://www.gersang.co.kr/pub/logi/login/login.gs?returnUrl=www.gersang.co.kr%2Fmain.gs');
-    await waitBusy();
+    await waitBusy(index);
   } catch (e) {
     dialog.showErrorBox('IE 오류!',
       '인터넷이 연결되어있지 않을 수도 있어요!');
+    event.reply('response-logout', {
+      error: true,
+      reason: 'login-failed',
+    });
+    mainWindow.setProgressBar(0);
+    return;
   }
   mainWindow.setProgressBar(0.2);
 
@@ -367,7 +373,7 @@ ipcMain.on('request-login', async (event, arg) => {
   document.querySelector('[src="/image/main/bt_login.gif"]').click();
 
   try {
-    await waitBusy();
+    await waitBusy(index);
   } catch {
     IE[index].Application.Quit();
     event.reply('response-logout', {
@@ -406,7 +412,7 @@ ipcMain.on('request-login', async (event, arg) => {
     mainWindow.setProgressBar(0.75);
   } else {
     IE[index].navigate('http://www.gersang.co.kr/main.gs');
-    await waitBusy();
+    await waitBusy(index);
     const logout = document.querySelector('[src="/image/main/txt_logout.gif"]');
     if (logout) {
       event.reply('response-login', {
@@ -431,7 +437,7 @@ ipcMain.on('request-otp', async (event, otpData: string) => {
   otp.innerText = otpData;
   document.querySelector('[src="/image/board/bt_le_ok.gif"]').click();
   try {
-    await waitBusy();
+    await waitBusy(currentIndex);
   } catch {
     mainWindow.webContents.send('response-logout', {
       error: true,
@@ -444,7 +450,7 @@ ipcMain.on('request-otp', async (event, otpData: string) => {
   for (let i = 0; i < 2; i += 1) {
     // cross check twice (occationally fails at first time)
     IE[currentIndex].navigate('https://www.gersang.co.kr/main.gs');
-    await waitBusy(); // eslint-disable-line
+    await waitBusy(currentIndex); // eslint-disable-line
     const logout = document.querySelector('[src="/image/main/txt_logout.gif"]');
     if (logout) {
       mainWindow.webContents.send('response-login', {
@@ -471,7 +477,7 @@ interface LogoutArgs {
 
 ipcMain.on('request-logout', (event, args: LogoutArgs) => {
   mainWindow.setProgressBar(0);
-  if (forced) {
+  if (args.forced) {
     mainWindow.webContents.send('response-logout', {
       error: true,
       reason: 'cancel-otp',
@@ -523,7 +529,7 @@ ipcMain.on('execute-game', (event, cliArg: CliArg) => {
             path.join(cliArg.path, file));
         });
       }
-      const document = IE[index].Document;
+      const document = IE[cliArg.index].Document;
       if (document) {
         document.parentWindow.execScript('gameStart(1)');
       } else {

--- a/public/config.json
+++ b/public/config.json
@@ -3,6 +3,7 @@
   "encrypted": "true",
   "clients": [
     {
+      "title": "",
       "username": "",
       "password": "",
       "path": "C:\\AKInteractive\\Gersang",
@@ -10,6 +11,7 @@
       "alwaysRestore": "true"
     },
     {
+      "title": "",
       "username": "",
       "password": "",
       "path": "C:\\AKInteractive\\Gersang2",
@@ -17,9 +19,18 @@
       "alwaysRestore": "true"
     },
     {
+      "title": "",
       "username": "",
       "password": "",
       "path": "C:\\AKInteractive\\Gersang3",
+      "alwaysSave": "false",
+      "alwaysRestore": "true"
+    },
+    {
+      "title": "",
+      "username": "",
+      "password": "",
+      "path": "C:\\AKInteractive\\Gersang4",
       "alwaysSave": "false",
       "alwaysRestore": "true"
     }

--- a/public/config.json
+++ b/public/config.json
@@ -27,7 +27,7 @@
       "alwaysRestore": "true"
     },
     {
-      "title": "",
+      "title": "상재용 서브",
       "username": "",
       "password": "",
       "path": "C:\\AKInteractive\\Gersang4",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import './App.css';
 const store = generateStore(reducer);
 
 ipcRenderer.on('hide', () => {
+  // eslint-disable-next-line
   const notification = new Notification('Gersang Supporter', {
     icon: NotificationIcon,
     body: '트레이 아이콘으로 숨깁니다.',

--- a/src/common/reducer/config/action.ts
+++ b/src/common/reducer/config/action.ts
@@ -11,6 +11,7 @@ export interface ConfigData {
   path: string;
   alwaysSave: string;
   alwaysRestore: string;
+  title?: string;
 }
 
 export interface ConfigState {
@@ -42,8 +43,10 @@ export const setAutoSave = (checked: boolean,
       } else {
         dispatch({
           type: SET_AUTOSAVE,
-          index,
-          checked,
+          payload: {
+            index,
+            checked,
+          },
         });
       }
     });
@@ -65,8 +68,10 @@ export const setAutoRestore = (checked: boolean,
       } else {
         dispatch({
           type: SET_AUTORESTORE,
-          index,
-          checked,
+          payload: {
+            index,
+            checked,
+          },
         });
       }
     });
@@ -112,26 +117,34 @@ export const setUserInfo = (username: string,
   }, {}, AnyAction> => async (dispatch, getState) => {
   dispatch({
     type: SET_USERINFO,
-    username: encrypt(username),
-    password: encrypt(password),
-    index,
+    payload: {
+      username: encrypt(username),
+      password: encrypt(password),
+      index,
+    },
   });
   dispatch(saveConfig({ doEncrypt: getState().config.encrypted === 'true' }, true));
 };
 
 export type ConfigActions = {
   type: typeof SET_AUTOSAVE,
-  index: number,
-  checked: boolean,
+  payload: {
+    index: number,
+    checked: boolean,
+  }
 } | {
   type: typeof SET_AUTORESTORE,
-  index: number,
-  checked: boolean,
+  payload: {
+    index: number,
+    checked: boolean,
+  }
 } | {
   type: typeof SET_USERINFO,
-  username: string,
-  password: string,
-  index: number,
+  payload: {
+    username: string,
+    password: string,
+    index: number,
+  }
 } | {
   type: typeof CONFIG_RELOAD,
 };

--- a/src/common/reducer/config/index.ts
+++ b/src/common/reducer/config/index.ts
@@ -23,20 +23,20 @@ const reducer = (state = initState(), action: ConfigActions) => {
   switch (action.type) {
     case SET_AUTOSAVE: {
       const newState = { ...state };
-      const checked = action.checked ? 'true' : 'false';
-      newState.clients[action.index].alwaysSave = checked;
+      const checked = action.payload.checked ? 'true' : 'false';
+      newState.clients[action.payload.index].alwaysSave = checked;
       return newState;
     }
     case SET_AUTORESTORE: {
       const newState = { ...state };
-      const checked = action.checked ? 'true' : 'false';
-      newState.clients[action.index].alwaysRestore = checked;
+      const checked = action.payload.checked ? 'true' : 'false';
+      newState.clients[action.payload.index].alwaysRestore = checked;
       return newState;
     }
     case SET_USERINFO: {
       const newState = { ...state };
-      newState.clients[action.index].username = action.username;
-      newState.clients[action.index].password = action.password;
+      newState.clients[action.payload.index].username = action.payload.username;
+      newState.clients[action.payload.index].password = action.payload.password;
       return newState;
     }
     case CONFIG_RELOAD: {

--- a/src/common/reducer/login/action.ts
+++ b/src/common/reducer/login/action.ts
@@ -1,5 +1,7 @@
 export const SET_STATUS = '@MAIN/SET_STATUS' as const;
 
+export const REINIT_ACTIVE_CLIENTS = '@MAIN/REINIT_ACTIVE_CLIENTS' as const;
+
 export enum EnumLoginState {
   AUTH_FAILED,
   LOGOUT,
@@ -10,14 +12,25 @@ export enum EnumLoginState {
 }
 
 export interface LoginState {
-  status: EnumLoginState;
-  clientIndex: number;
+  clients: Array<{
+    status: EnumLoginState;
+  }>
 }
 
 export const setStatus = (index: number, status: EnumLoginState) => ({
   type: SET_STATUS,
-  index,
-  status,
+  payload: {
+    index,
+    status,
+  },
 });
 
-export type MainActions = ReturnType<typeof setStatus>;
+export const reInitActiveClients = (clientLength: number) => ({
+  type: REINIT_ACTIVE_CLIENTS,
+  payload: {
+    clientLength,
+  },
+});
+
+export type MainActions = ReturnType<typeof setStatus> |
+  ReturnType<typeof reInitActiveClients>;

--- a/src/common/reducer/login/index.ts
+++ b/src/common/reducer/login/index.ts
@@ -1,20 +1,45 @@
 import { Reducer } from 'redux';
-import { EnumLoginState, MainActions, LoginState } from './action';
+import {
+  EnumLoginState, MainActions, LoginState,
+  REINIT_ACTIVE_CLIENTS, SET_STATUS,
+} from './action';
 
 
 const initState = (): LoginState => ({
-  status: EnumLoginState.LOGOUT,
-  clientIndex: 0,
+  clients: [{
+    status: EnumLoginState.LOGOUT,
+  }, {
+    status: EnumLoginState.LOGOUT,
+  }, {
+    status: EnumLoginState.LOGOUT,
+  }],
 });
 
 
 const reducer = (state = initState(), action: MainActions) => {
   switch (action.type) {
-    case '@MAIN/SET_STATUS':
-      return {
-        status: action.status,
-        clientIndex: action.index,
+    case SET_STATUS: {
+      const newState = {
+        ...state,
       };
+      newState.clients[action.payload.index].status = action.payload.status;
+      return newState;
+    }
+    case REINIT_ACTIVE_CLIENTS: {
+      const newClients = [];
+      for (let i = 0; i < action.payload.clientLength; i += 1) {
+        newClients.push({
+          status: EnumLoginState.LOGOUT,
+        });
+        if (state.clients[i]) {
+          // copy current state if exists.
+          newClients[i].status = state.clients[i].status;
+        }
+      }
+      return {
+        clients: newClients,
+      };
+    }
     default:
       break;
   }

--- a/src/common/reducer/stopwatch/index.ts
+++ b/src/common/reducer/stopwatch/index.ts
@@ -1,5 +1,5 @@
 import { Reducer } from 'redux';
-import { NotificationIcon } from '@common/icons';
+// import { NotificationIcon } from '@common/icons';
 import {
   StopWatchActions, SET_BASE_TIME,
   INCREASE_ELAPSED_TIME, SET_STATUS, StopWatchState,

--- a/src/common/reducer/timer/index.ts
+++ b/src/common/reducer/timer/index.ts
@@ -33,6 +33,7 @@ const reducer = (state = initState(), action: TimerActions) => {
     case DECREASE_LEFT_TIME: {
       if (state.status === 'START'
         && state.leftTime - action.time < 0) {
+        // eslint-disable-next-line
         const t = new Notification('Gersang Supporter', {
           icon: NotificationIcon,
           body: '시간이 경과되었어요 !',

--- a/src/routes/main/login-form.tsx
+++ b/src/routes/main/login-form.tsx
@@ -1,0 +1,302 @@
+import { ipcRenderer, IpcRendererEvent, remote } from 'electron';
+import React, {
+  useEffect, useRef, KeyboardEvent, useState, useCallback,
+} from 'react';
+import TextBox from 'react-uwp/TextBox';
+import PasswordBox from 'react-uwp/PasswordBox';
+import Icon from 'react-uwp/Icon';
+import Button from 'react-uwp/Button';
+import ProgressBar from 'react-uwp/ProgressBar';
+import ProgressRing from 'react-uwp/ProgressRing';
+import CheckBox from 'react-uwp/CheckBox';
+import { GlobalState } from '@common/reducer';
+import { decrypt } from '@common/constant';
+import styled from 'styled-components';
+import { useSelector, useDispatch } from 'react-redux';
+import {
+  setAutoSave, setAutoRestore, setUserInfo,
+} from '@common/reducer/config/action';
+import { setStatus, EnumLoginState as LoginState } from '@common/reducer/login/action';
+
+const ClientLayout = styled.div`
+  padding-top: 2rem;
+  padding-bottom: 3rem;
+  display: flex;
+  flex-direction: column;
+  width: calc(100vw - 48px);
+  align-items: center;
+  > * {
+    margin-bottom: 0.5rem;
+  }
+`;
+
+const CommandButtons = styled.div`
+  display: flex;
+  justify-content: space-around;
+  > * {
+    margin: 0 0.5rem 0 0.5rem;
+  }
+`;
+
+const WarnTitle = styled.span`
+  position: absolute;
+  top: 0.5rem;
+  color: red;
+  user-select: none;
+`;
+
+const PathInfo = styled.span`
+  position: absolute;
+  bottom: 0;
+  color: #858585;
+`;
+
+const AlignLeft = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  padding: 0 2rem 1rem;
+  margin: -3px;
+
+  > * {
+    margin: 3px;
+  }
+`;
+
+const style = {
+  margin: '0 8px',
+};
+
+const passwordStyle = {
+  paddingLeft: 0,
+};
+
+interface LoginResponse {
+  status: boolean;
+  reason?: string;
+}
+
+interface LogoutResponse {
+  error: boolean;
+  reason?: string;
+}
+
+interface LoginFormProps {
+  index: number;
+}
+const LoginForm: React.FC<LoginFormProps> = ({ index }) => {
+  const idRef = useRef<TextBox>(null);
+  const pwRef = useRef<PasswordBox>(null);
+  const loginState = useSelector((state: GlobalState) => state.login.clients[index].status);
+  const isEncrypted = useSelector((state: GlobalState) => state.config.encrypted);
+  const config = useSelector((state: GlobalState) => state.config.clients[index]);
+  const restorePath = useSelector((state: GlobalState) => state.config.clients[0].path);
+
+  const [pending, setPending] = useState<number>(0);
+  const dispatch = useDispatch();
+
+  const requestLogout = useCallback(() => {
+    ipcRenderer.send('request-logout', {
+      index,
+      forced: false,
+    });
+  }, [index]);
+
+  const requestLogin = useCallback(() => {
+    if (pending > 0) return;
+    if (loginState === LoginState.LOGIN) {
+      requestLogout();
+      return;
+    }
+    if (loginState !== LoginState.LOGOUT) return;
+
+    const id = idRef.current!.getValue().trim();
+    const password = pwRef.current!.getValue().trim();
+    if (!id || !password) {
+      remote.dialog.showErrorBox('킹갓 근본 에러',
+        '아이디 혹은 비밀번호가 공란이에요!');
+      return;
+    }
+    ipcRenderer.send('request-login', {
+      id,
+      password,
+      index,
+    });
+    dispatch(setStatus(index, LoginState.SEND_AUTH));
+    // setLoginState(LoginState.SEND_AUTH);
+  }, [dispatch, index, loginState, pending, requestLogout]);
+
+
+
+  const requestGameExecute = () => {
+    ipcRenderer.send('execute-game', {
+      index,
+      path: config.path,
+      restorePath,
+      restore: config.alwaysRestore === 'true',
+    }); // set client number
+  };
+
+  const onKeyPress = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      e.stopPropagation();
+      requestLogin();
+    }
+  };
+
+  const toggleSaveConfig = (checked?: boolean) => {
+    dispatch(setAutoSave(checked || false, index));
+  };
+
+  const toggleRestoreConfig = (checked?: boolean) => {
+    dispatch(setAutoRestore(checked || false, index));
+  };
+
+  useEffect(() => {
+    if (config) {
+      if (idRef && idRef.current
+        && pwRef && pwRef.current) {
+        if (isEncrypted === 'true') {
+          idRef.current!.setValue(decrypt(config.username));
+          pwRef.current!.setValue(decrypt(config.password));
+        } else {
+          idRef.current!.setValue(config.username);
+          pwRef.current!.setValue(config.password);
+        }
+      }
+    }
+  }, [config, idRef, isEncrypted, pwRef]);
+
+  useEffect(() => {
+    const responseLoginCallback = (event: IpcRendererEvent, res: LoginResponse) => {
+      if (res.status) {
+        if (config.alwaysSave === 'true') {
+          dispatch(setUserInfo(
+            idRef.current!.getValue(),
+            pwRef.current!.getValue(),
+            index,
+          ));
+        }
+        dispatch(setStatus(index, LoginState.LOGIN));
+      } else if (res.reason === 'OTP_AUTH_REQUIRED') {
+        dispatch(setStatus(index, LoginState.WAIT_OTP));
+      }
+    };
+
+    const responseLogoutCallback = (event: IpcRendererEvent, res: LogoutResponse) => {
+      if (res.error) {
+        setPending(5);
+        // remote.dialog.showErrorBox('알 수 없는 오류!',
+        //   `알 수 없는 오류입니다 T.T
+        //   ${JSON.stringify(res)}`);
+      }
+      dispatch(setStatus(index, LoginState.LOGOUT));
+    };
+    ipcRenderer.on('response-login', responseLoginCallback);
+    ipcRenderer.on('response-logout', responseLogoutCallback);
+    return () => {
+      ipcRenderer.off('response-login', responseLoginCallback);
+      ipcRenderer.off('response-logout', responseLogoutCallback);
+    };
+  }, [config.alwaysSave, dispatch, index, idRef, pwRef]);
+
+  useEffect(() => {
+    let interval: number;
+    if (pending > 0) {
+      interval = setInterval(() => {
+        setPending(pending - 0.1);
+      }, 100);
+    }
+    return () => clearInterval(interval);
+  }, [pending]);
+
+  const isAuthenticating = (loginState >= LoginState.SEND_AUTH
+    && loginState <= LoginState.SEND_OTP);
+
+  const isLoggedIn = loginState === LoginState.LOGIN;
+  return (
+    <ClientLayout>
+      {/* {(loginIndex !== index)
+        && (
+        <WarnTitle>
+          현재&nbsp;
+          {loginIndex + 1}
+          클이 활성화되어 있습니다.
+        </WarnTitle>
+        )} */}
+      <TextBox
+        background="none"
+        placeholder="아이디를 입력해주세요"
+        rightNode={<Icon style={style}>Emoji2Legacy</Icon>}
+        ref={idRef}
+        onKeyPress={onKeyPress}
+      />
+      <PasswordBox
+        placeholder="Password"
+        ref={pwRef}
+        onKeyPress={onKeyPress}
+        style={passwordStyle}
+      />
+      <AlignLeft>
+        <CheckBox
+          label="로그인에 성공할 경우 로그인 정보 저장하기"
+          defaultChecked={config.alwaysSave === 'true'}
+          onCheck={toggleSaveConfig}
+          style={{
+            userSelect: 'none',
+          }}
+        />
+        <CheckBox
+          label="게임 실행전 클라이언트 변조 현상 항상 복구"
+          defaultChecked={config.alwaysRestore === 'true'}
+          disabled={index === 0}
+          onCheck={toggleRestoreConfig}
+          style={{
+            userSelect: 'none',
+          }}
+        />
+      </AlignLeft>
+      <CommandButtons>
+        {(!isLoggedIn)
+          && (
+          <Button
+            onClick={requestLogin}
+            disabled={isAuthenticating || pending > 0}
+            style={{ position: 'relative' }}
+          >
+            로그인
+            <ProgressBar
+              barWidth={76}
+              style={{
+                position: 'absolute',
+                left: '-2px',
+                bottom: '-2px',
+                display: pending > 0 ? 'block' : 'none',
+              }}
+              defaultProgressValue={pending * 0.2}
+            />
+          </Button>
+          )}
+        {(isLoggedIn)
+          && (
+          <Button onClick={requestLogout}>
+            로그아웃
+          </Button>
+          )}
+        <Button disabled>
+        출석 체크
+        </Button>
+        <Button disabled={!isLoggedIn} onClick={requestGameExecute}>
+        게임 실행
+        </Button>
+      </CommandButtons>
+      <PathInfo>
+        경로:&nbsp;
+        {config.path}
+      </PathInfo>
+      {isAuthenticating && (<ProgressRing size={25} />)}
+    </ClientLayout>
+  );
+};
+
+export default LoginForm;

--- a/src/routes/main/login-form.tsx
+++ b/src/routes/main/login-form.tsx
@@ -38,12 +38,12 @@ const CommandButtons = styled.div`
   }
 `;
 
-const WarnTitle = styled.span`
-  position: absolute;
-  top: 0.5rem;
-  color: red;
-  user-select: none;
-`;
+// const WarnTitle = styled.span`
+//   position: absolute;
+//   top: 0.5rem;
+//   color: red;
+//   user-select: none;
+// `;
 
 const PathInfo = styled.span`
   position: absolute;


### PR DESCRIPTION
## 변경점

### 신규 기능 & 개선
- 커스텀 클라이언트 탭
  - 탭을 추가하거나 제거할 수 있도록 기능을 추가하였습니다.
  - 탭의 이름을 설정해줄 수 있습니다.
  - **해당 기능은 현재 별도 UI가 존재하지 않습니다. 필요시 설치된 폴더의 config.json 양식을 수정해주세요.**
  - **관련한 자세한 설명은 하단을 참고해주세요.**
- 각 클라이언트 로그인 후 실행 시 다른 클라이언트의 활성화 여부를 신경쓰지 않아도 되도록 개선하였습니다.
  - 각 클라이언트가 로그인 되어있을 경우 추후 실행 시(ex. 종료 후 재실행 등) 별도의 추가 로그인 필요 없이 클라이언트를 실행할 수 있도록 개선하였습니다.
- 거상 서포터 가로 길이를 소폭 증가 시켰습니다.
- 탭 기본 이름이 변경되었습니다(ex. 1번 계정 -> 1번).

### 클라이언트 탭 추가/변경 방법
>` config.json`을 잘못 수정하여 프로그램 오동작 시 `config.json`파일을 지워서 초기화해주세요!

1. 거상 서포터가 설치된 폴더의 config.json 파일을 엽니다.
2. `clients` 키 안에 담겨있는 내용을 수정합니다.
clients 키는 배열에 JSON 데이터가 담기는 형태로 구성되어 있습니다.
```
{
      "title": "",
      "username": "",
      "password": "",
      "path": "C:\\AKInteractive\\Gersang",
      "alwaysSave": "false",
      "alwaysRestore": "true"
    }
```
`title`: 탭이 거상 서포터에서 보여질 이름
`username`: 유저 id
`password`: 유저 pw
> (암호화 선택 시 id와 비밀번호가 암호화되어 저장됩니다)

`path`: 거상 클라이언트가 저장되어 있는 폴더
`alwaysSave`: 로그인 성공 시 아이디 정보를 이 파일에 저장할지에 대한 여부
`alwaysRestore`: 게임 실행 시 항상 클라이언트를 복구할지 여부(패치가 없는 날이면 체크해제해도 무방합니다)

위 옵션 중 `title` 외엔 거상 서포터 내부 UI를 통해 설정 가능하기에 그 외의 내용에 대해 수동으로 조작하는 것은 권장하지 않습니다.
탭을 추가 혹은 제거 하려면 배열 안에 위 내용을 추가하거나 제거하시면 됩니다.

> **탭을 추가하더라도 3클 이상 켜는 특수한 기능은 거상 서포터엔 없습니다! 거상 서포터는 거상 운영정책을 준수합니다!**

### 버그 수정
- 로그인 과정에서 인터넷 연결 문제 등으로 인하여 실패하였을 시 초기 상태로 돌아오지 못하는 문제를 수정하였습니다.
- 의존성 라이브러리 버전업에 의한 메인 프로세스의 동작 오류를 수정하였습니다(win32 API, activeX 관련).